### PR TITLE
feat: Execute commands in a separate child process

### DIFF
--- a/podman.c
+++ b/podman.c
@@ -1,27 +1,68 @@
-#include "headers.h"
+#include "headers.h" // Make sure sys/wait.h and unistd.h are included via headers.h
 
 int main(int argc, char *argv[]) {
+    pid_t child_pid;
+    int status;
 
-    /*
-     * Attempting to mimic docker exec: directly executing the provided command.
-     * WARNING: This does NOT provide any container isolation. Running arbitrary
-     * commands without proper sandboxing or namespaces is dangerous.
-     */
-    
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <command> [args...]\n", argv[0]);
         exit(EXIT_FAILURE);
     }
 
-    printf("running: %s", argv[1]);
-    for (int i = 2; i < argc; i++) {
-        printf(" %s", argv[i]);
+    printf("[Parent:%ld] Forking process to run: ", (long)getpid());
+    for (int i = 1; i < argc; i++) {
+        printf("%s ", argv[i]);
     }
     printf("\n");
-    
-    execvp(argv[1], argv + 1);
-    perror("execvp failed");
-    exit(EXIT_FAILURE);
 
+    child_pid = fork();
+
+    if (child_pid == -1) {
+        // Fork failed
+        perror("[Parent] fork failed");
+        exit(EXIT_FAILURE);
+    } else if (child_pid == 0) {
+        // --- Child Process ---
+        printf("[Child:%ld] Executing command: %s\n", (long)getpid(), argv[1]);
+
+        // Prepare arguments for execvp: argv + 1 points to the command itself
+        char **child_argv = &argv[1];
+
+        execvp(child_argv[0], child_argv);
+
+        // If execvp returns, an error occurred
+        perror("[Child] execvp failed");
+        // Exit the child process with failure status
+        // _exit() is often preferred over exit() after fork without exec
+        // to avoid running stdio cleanup routines twice.
+        _exit(EXIT_FAILURE);
+
+    } else {
+        // --- Parent Process ---
+        printf("[Parent:%ld] Waiting for child process (PID: %ld) to finish...\n", (long)getpid(), (long)child_pid);
+
+        // Wait for the specific child process to change state
+        if (waitpid(child_pid, &status, 0) == -1) {
+            perror("[Parent] waitpid failed");
+            exit(EXIT_FAILURE);
+        }
+
+        // Check how the child terminated
+        if (WIFEXITED(status)) {
+            printf("[Parent:%ld] Child process (PID: %ld) exited normally with status: %d\n",
+                   (long)getpid(), (long)child_pid, WEXITSTATUS(status));
+        } else if (WIFSIGNALED(status)) {
+            printf("[Parent:%ld] Child process (PID: %ld) killed by signal: %d\n",
+                   (long)getpid(), (long)child_pid, WTERMSIG(status));
+        } else {
+            printf("[Parent:%ld] Child process (PID: %ld) exited with unknown status.\n",
+                   (long)getpid(), (long)child_pid);
+        }
+
+        printf("[Parent:%ld] Exiting.\n", (long)getpid());
+        exit(EXIT_SUCCESS); // Exit parent successfully
+    }
+
+    // This line should not be reached
     return 0;
 }


### PR DESCRIPTION

**Description:**

The previous version of `podman.c` used `execvp` directly within the main process. This meant that the `podman` program itself was immediately replaced by the user-specified command, offering no opportunity for the original `podman` process to monitor or manage the command it launched.

This PR modifies the execution flow to address this limitation. Instead of replacing itself, `podman` now creates a *new*, separate child process specifically to run the user's command. The original `podman` process (the parent) remains running and waits for the command (child) to complete.

**Changes Introduced:**

*   **Process Creation:** Instead of directly calling `execvp`, the program now uses the `fork()` system call to create a distinct child process.
*   **Child Execution:** The responsibility of executing the user's command via `execvp` (using `argv[1:]`) is moved into the newly created child process. If `execvp` fails within the child, the child now explicitly exits with a failure status.
*   **Parent Waiting:** The original (parent) process no longer executes the command itself. Instead, it calls `waitpid()` to pause and wait specifically for the child process it created to terminate.
*   **Status Reporting:** After the child process finishes, the parent process retrieves the child's termination status using `waitpid`. It then analyzes this status (using `WIFEXITED`, `WEXITSTATUS`, `WIFSIGNALED`, `WTERMSIG` macros) and prints information about how the child command concluded (normal exit with status code, or termination via signal).
*   **Improved Logging:** Added `[Parent:PID]` and `[Child:PID]` prefixes to `printf` statements to clearly distinguish the output originating from the parent process versus the child process running the command.
*   **Error Handling:** Basic error checking for `fork()` and `waitpid()` system call failures has been added to the parent process.

**Benefit:**

This change introduces a fundamental separation between the launcher (`podman`) and the command being executed. The `podman` program now acts as a proper parent process, initiating the command in a child and having the capability to observe its completion and exit status.

**How to Test:**

1.  Compile the modified `podman.c`.
2.  Run it with a simple command, e.g.:
    *   `./podman /bin/ls -l /tmp`
    *   `./podman /bin/echo "Hello from child"`
    *   `./podman /bin/sleep 3`
3.  Observe the output logs, noting the distinct messages from the parent and child PIDs.
4.  Verify that the parent process waits until the child command finishes and then prints a message indicating the child's exit status or termination signal.

---