### PR TITLE
 feat: Introduce Namespaces and Two-Phase Init for Basic Container Isolation

### DIFF
--- a/podman.c
+++ b/podman.c
@@ -1,68 +1,165 @@
-#include "headers.h" // Make sure sys/wait.h and unistd.h are included via headers.h
+#include "headers.h" 
+#define STACK_SIZE (1024 * 1024) // 1MB stack
+#define CONTAINER_HOSTNAME "container-1"
 
+static int container_init(char *program_name, char *const command_argv[]);
+static int child_shim_func(void *arg);
+
+static int child_shim_func(void *arg) {
+    char **original_argv = (char **)arg;
+    int original_argc = 0;
+    while (original_argv[original_argc] != NULL) {
+        original_argc++;
+    }
+
+    /*  We need to construct a new argv for the self-exec:
+        ["/proc/self/exe", "init", original_argv[1], original_argv[2], ..., NULL]
+        Size needed: 1 (exe) + 1 (init) + (original_argc - 1) (command+args) + 1 (NULL) = original_argc + 2
+    */
+    
+    char *new_argv[original_argc + 2];
+
+    new_argv[0] = "/proc/self/exe";
+    new_argv[1] = "init";
+
+    // Copy the original command and its arguments (starting from original_argv[1])
+    for (int i = 1; i < original_argc; i++) {
+        new_argv[i + 1] = original_argv[i];
+    }
+    new_argv[original_argc + 1] = NULL; // Null-terminate the new argv array
+
+    printf("[Shim:%ld] Parent PID: %ld. Executing 'init' phase via /proc/self/exe...\n", (long)getpid(), (long)getppid());
+    printf("[Shim:%ld] New argv for execve: ", (long)getpid());
+    for (int i = 0; new_argv[i] != NULL; i++) {
+        printf("'%s' ", new_argv[i]);
+    }
+    printf("\n");
+
+    // Ensure PATH might be inherited or set default if needed
+    extern char **environ; // Use the environment from the parent initially
+
+    execve("/proc/self/exe", new_argv, environ);
+
+    // If execve returns, it's an error
+    perror("[Shim] execve failed");
+    // Use _exit in child/shim after clone/fork before final exec if possible
+    _exit(EXIT_FAILURE);
+}
+
+// --- Container Init Function (runs after self-exec, called from main) ---
+// program_name is argv[0] ("/proc/self/exe"), command_argv is &argv[2] from main
+static int container_init(char *program_name, char *const command_argv[]) {
+    printf("[Init:%ld] Running container_init (Parent PID: %ld)\n", (long)getpid(), (long)getppid());
+
+    // --- UTS Namespace Setup ---
+    printf("[Init:%ld] Setting hostname to '%s'...\n", (long)getpid(), CONTAINER_HOSTNAME);
+    if (sethostname(CONTAINER_HOSTNAME, strlen(CONTAINER_HOSTNAME)) == -1) {
+        perror("[Init] sethostname failed");
+        // In a real scenario, more cleanup might be needed.
+        // For now, just exit.
+        return EXIT_FAILURE; // Return failure from init
+    }
+    printf("[Init:%ld] Hostname set.\n", (long)getpid());
+
+    // --- Execute the final user process ---
+    // command_argv[0] is the command, command_argv is the full argv array for it.
+    printf("[Init:%ld] Executing final command: %s\n", (long)getpid(), command_argv[0]);
+    execvp(command_argv[0], command_argv);
+
+    // If execvp returns, it failed
+    perror("[Init] final execvp failed");
+    return EXIT_FAILURE; // Return failure from init
+}
+
+
+// --- Main Function ---
 int main(int argc, char *argv[]) {
-    pid_t child_pid;
-    int status;
+    /*
+    This function is the entry point, and we will check if we need to run the "init" phase
+    or, as the parent, set up the container and call the shim function.
+    The "init" phase is responsible for setting up the container environment and executing the
+    final command. The parent process will create a new process using clone() and wait for it to finish.
 
+    To check if the namespaces are set up correctly, we can use the following command:
+    gcc podman.c -o podman.c -o podman.c -Wall -Werror -std=gnu99
+    sudo ./podman.c /bin/bash
+    Please note the changed hostname in the prompt.
+    It should say "user@container-1" instead of "user@host", depending on your shell settings.
+    You can also check the hostname using the "hostname" command.
+    Once you are done, please exit the shell.
+    The container will be cleaned up automatically when the process exits.
+    You can now check your hostname again, if you wish.
+    */
+
+    // --- Check if we are in the "init" phase ---
+    if (argc > 1 && strcmp(argv[1], "init") == 0) {
+        if (argc < 3) {
+            fprintf(stderr, "[Init:%ld] Error: 'init' requires a command to run.\n", (long)getpid());
+            exit(EXIT_FAILURE);
+        }
+        // Pass the program name (ignored by init) and the command+args part (&argv[2])
+        // The return value from container_init indicates success/failure *if* execvp fails
+        exit(container_init(argv[0], &argv[2]));
+    }
+
+    // --- Otherwise, we are in the "create" phase (parent) ---
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <command> [args...]\n", argv[0]);
         exit(EXIT_FAILURE);
     }
 
-    printf("[Parent:%ld] Forking process to run: ", (long)getpid());
+    void *child_stack = NULL;
+    void *stack_top = NULL;
+    pid_t child_pid;
+    int status;
+
+    printf("[Parent:%ld] Starting container setup (create phase)...\n", (long)getpid());
+    printf("[Parent:%ld] Command to run in container: ", (long)getpid());
     for (int i = 1; i < argc; i++) {
         printf("%s ", argv[i]);
     }
     printf("\n");
 
-    child_pid = fork();
+    // Allocate stack for the child process
+    child_stack = malloc(STACK_SIZE);
+    if (child_stack == NULL) {
+        perror("[Parent] Failed to allocate stack");
+        exit(EXIT_FAILURE);
+    }
+    stack_top = child_stack + STACK_SIZE; // Point to the top of the stack
+    printf("[Parent:%ld] Allocated %d bytes stack for child.\n", (long)getpid(), STACK_SIZE);
+
+    // Flags for clone: New UTS namespace + Send SIGCHLD to parent on termination
+    int clone_flags = CLONE_NEWUTS | SIGCHLD;
+    printf("[Parent:%ld] Calling clone() with flags: CLONE_NEWUTS | SIGCHLD\n", (long)getpid());
+
+    // Pass the original argv to the shim function via the 'arg' parameter
+    child_pid = clone(child_shim_func, stack_top, clone_flags, argv);
 
     if (child_pid == -1) {
-        // Fork failed
-        perror("[Parent] fork failed");
+        perror("[Parent] clone failed");
+        free(child_stack); // Clean up stack on failure
         exit(EXIT_FAILURE);
-    } else if (child_pid == 0) {
-        // --- Child Process ---
-        printf("[Child:%ld] Executing command: %s\n", (long)getpid(), argv[1]);
+    }
+    printf("[Parent:%ld] Cloned shim process with PID: %ld\n", (long)getpid(), (long)child_pid);
 
-        // Prepare arguments for execvp: argv + 1 points to the command itself
-        char **child_argv = &argv[1];
-
-        execvp(child_argv[0], child_argv);
-
-        // If execvp returns, an error occurred
-        perror("[Child] execvp failed");
-        // Exit the child process with failure status
-        // _exit() is often preferred over exit() after fork without exec
-        // to avoid running stdio cleanup routines twice.
-        _exit(EXIT_FAILURE);
-
+    // --- Parent Waits ---
+    printf("[Parent:%ld] Waiting for container process (original PID %ld) to exit...\n", (long)getpid(), (long)child_pid);
+    if (waitpid(child_pid, &status, 0) == -1) {
+        perror("[Parent] waitpid failed");
+        // Still try to free stack
     } else {
-        // --- Parent Process ---
-        printf("[Parent:%ld] Waiting for child process (PID: %ld) to finish...\n", (long)getpid(), (long)child_pid);
-
-        // Wait for the specific child process to change state
-        if (waitpid(child_pid, &status, 0) == -1) {
-            perror("[Parent] waitpid failed");
-            exit(EXIT_FAILURE);
-        }
-
-        // Check how the child terminated
         if (WIFEXITED(status)) {
-            printf("[Parent:%ld] Child process (PID: %ld) exited normally with status: %d\n",
-                   (long)getpid(), (long)child_pid, WEXITSTATUS(status));
+            printf("[Parent:%ld] Container process exited normally with status: %d\n", (long)getpid(), WEXITSTATUS(status));
         } else if (WIFSIGNALED(status)) {
-            printf("[Parent:%ld] Child process (PID: %ld) killed by signal: %d\n",
-                   (long)getpid(), (long)child_pid, WTERMSIG(status));
+            printf("[Parent:%ld] Container process killed by signal: %d\n", (long)getpid(), WTERMSIG(status));
         } else {
-            printf("[Parent:%ld] Child process (PID: %ld) exited with unknown status.\n",
-                   (long)getpid(), (long)child_pid);
+            printf("[Parent:%ld] Container process exited with unknown status.\n", (long)getpid());
         }
-
-        printf("[Parent:%ld] Exiting.\n", (long)getpid());
-        exit(EXIT_SUCCESS); // Exit parent successfully
     }
 
-    // This line should not be reached
-    return 0;
+    // Clean up
+    free(child_stack);
+    printf("[Parent:%ld] Exiting.\n", (long)getpid());
+    return WIFEXITED(status) ? WEXITSTATUS(status) : EXIT_FAILURE; // Return child's exit status or failure
 }


### PR DESCRIPTION

This pull request refactors the simple process runner podman.c into a foundational container runtime  by introducing core concepts fundamental to containerization. The focus shifts from merely running a sub-process to creating an isolated environment for that process.

**Key Concepts Introduced/Changes:**

1.  **Process Creation with `clone()` vs. `fork()`:**
    *   The previous version used `fork()`, which creates a near-identical copy of the parent process.
    *   The new version utilizes `clone()`, a more granular system call. This is crucial because `clone()` allows specifying flags to create the child process in *new Linux namespaces*, which is the primary mechanism for achieving container isolation.

2.  **Introduction of Linux Namespaces (UTS):**
    *   `CLONE_NEWUTS` flag is passed to `clone()`. This creates a new UTS (Unix Timesharing System) namespace for the child process.
    *   **Concept:** Namespaces provide isolation. Processes within a UTS namespace have their own independent hostname and NIS domain name, separate from the host system and other namespaces. This demonstrates the first step towards resource isolation.

3.  **Two-Phase Initialization Pattern:**
    *   The simple `fork()` -> `execvp()` model is replaced by a more complex, multi-stage initialization required for setup *within* the isolated environment.
    *   **Phase 1 (Parent/Create):** The main process (`main` when not invoked with `init`) allocates resources (like the child's stack) and uses `clone()` to create the initial child (the "shim").
    *   **Shim Process (`child_shim_func`):** This short-lived process runs immediately after `clone()`. Its primary role is to prepare arguments and use `execve` with `/proc/self/exe` to re-execute the program itself, but passing an `init` argument. This self-execution is a common pattern to get a clean process state *after* namespace creation but *before* running the final user command.
    *   **Phase 2 (Child/Init - `container_init`):** Triggered by the `init` argument after the self-exec. This code runs *inside* the new namespaces created by `clone()`. It performs container-specific setup (like setting the hostname using `sethostname()`). Only *after* this setup does it finally `execvp()` the user's intended command.
    *   **Concept:** This pattern allows performing configuration tasks within the context of the newly created namespaces, which wouldn't be possible if the parent directly `exec`'d the final command after `fork/clone`.

4.  **Manual Stack Management for `clone()`:**
    *   Unlike `fork()`, `clone()` (when not using `CLONE_VM`) requires the caller to manually allocate memory for the child process's stack.
    *   **Concept:** This highlights the lower-level control `clone()` provides and the associated responsibilities, contrasting with the more automatic resource duplication of `fork()`.

5.  **Self-Execution (`/proc/self/exe`):**
    *   Using `/proc/self/exe` in the shim allows the *same* program binary to handle both the initial container creation logic and the subsequent initialization logic inside the container, distinguished by command-line arguments.
    *   **Concept:** Demonstrates a powerful technique for managing different execution stages within a single executable, often used in init systems and container runtimes.

6.  **Explicit `SIGCHLD`:**
    *   The `SIGCHLD` flag is explicitly passed to `clone()`. While `fork()` implicitly arranges for the parent to receive `SIGCHLD` when the child terminates, it's good practice to be explicit with `clone()` if relying on `waitpid()`.
    *   **Concept:** Reinforces understanding of process lifecycle signals and parent/child interaction primitives.

**Summary:**

This change moves from a simple process launcher to a rudimentary container runtime foundation. It introduces the concepts of **namespace isolation (UTS)**, process creation via **`clone()`**, the necessity of **manual stack management** with `clone()`, and a **two-phase initialization pattern** using **self-execution** to perform setup within the isolated environment before running the target command. This provides a much richer example for understanding how containerization primitives work at a low level.