### PR TITLE
pivot root, new virtfs setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Building a Simple Container Manager in C
 
-   Add mount namepsace isolation, and mount a seperate /proc directory inside the container. The container now correctly sees it's own process tree, instead of the host process tree
+   Use the `pivot_root` syscall to mount a new root directory for our container, isolating the host file system from the process
+   Add a readonly sys mount and some necessary defaults for dev (devtmpfs)
 
 ## Repository Structure
 

--- a/src/libcapsule/libcapsule.c
+++ b/src/libcapsule/libcapsule.c
@@ -1,28 +1,34 @@
-#define _GNU_SOURCE 
+#define _GNU_SOURCE
 
-#include "libcapsule.h"
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/sysmacros.h>
 #include <sys/wait.h>
-#include <sys/mount.h> 
-#include <signal.h> 
-#include <sched.h>
-#include <errno.h>
+#include <unistd.h>
+
+#include "libcapsule.h"
 
 #ifndef CLONE_FLAGS
 #define CLONE_FLAGS (CLONE_NEWPID | CLONE_NEWUTS | CLONE_NEWNS | SIGCHLD)
 #endif
 
-static int child_shim_func(void *arg) {
-    char **original_argv = (char **)arg;
+static int
+child_shim_func(void* arg)
+{
+    char** original_argv = (char**)arg;
     int original_argc = 0;
     while (original_argv[original_argc] != NULL) {
         original_argc++;
     }
 
-    char *new_argv[original_argc + 3];
+    char* new_argv[original_argc + 3];
     new_argv[0] = "/proc/self/exe";
     new_argv[1] = "init";
     for (int i = 0; i < original_argc; i++) {
@@ -30,14 +36,16 @@ static int child_shim_func(void *arg) {
     }
     new_argv[original_argc + 2] = NULL;
 
-    extern char **environ;
+    extern char** environ;
     execve("/proc/self/exe", new_argv, environ);
 
     perror("[Shim] execve failed");
     _exit(EXIT_FAILURE);
 }
 
-int create_container_argv(char *const argv[], libcapsule_container_state_t *state) {
+int
+create_container_argv(char* const argv[], libcapsule_container_state_t* state)
+{
     if (!argv || !argv[0] || !state) {
         errno = EINVAL;
         return -1;
@@ -46,94 +54,227 @@ int create_container_argv(char *const argv[], libcapsule_container_state_t *stat
     state->host_pid = -1;
     state->exit_status = -1;
     state->child_stack = NULL; // Important initialization
-    
 
-    void *child_stack = malloc(STACK_SIZE);
+    void* child_stack = malloc(STACK_SIZE);
     if (!child_stack) {
         perror("[Parent] Failed to allocate stack");
-
         return -1;
     }
 
-    state->child_stack = child_stack; 
-    
-    void *stack_top = child_stack + STACK_SIZE;
+    state->child_stack = child_stack;
+
+    void* stack_top = child_stack + STACK_SIZE;
     int clone_flags = CLONE_FLAGS;
 
-    pid_t child_pid = clone(child_shim_func, stack_top, clone_flags, (void*) argv);
+    pid_t child_pid =
+      clone(child_shim_func, stack_top, clone_flags, (void*)argv);
 
     if (child_pid == -1) {
         perror("[Parent] clone failed");
         free(state->child_stack);
         state->child_stack = NULL;
-        return -1; 
+        return -1;
     }
 
-    printf("[Parent] Created container process with Host PID: %ld\n", (long)child_pid);
+    printf("[Parent] Created container process with Host PID: %ld\n",
+           (long)child_pid);
 
     state->host_pid = child_pid;
-   
-
 
     return 0; // Return success
 }
 
-int create_container_simple(const char *command, libcapsule_container_state_t *state) {
+int
+create_container_simple(const char* command,
+                        libcapsule_container_state_t* state)
+{
     if (!command || !state) {
         errno = EINVAL;
         return -1;
     }
-    char *argv[] = { "/bin/sh", "-c", (char *)command, NULL };
+    char* argv[] = { "/bin/sh", "-c", (char*)command, NULL };
     return create_container_argv(argv, state);
 }
 
+int
+init_container(const char* program_name, char* const command_argv[])
+{
+    char old_root_path[256];
 
-int init_container(const char *program_name, char *const command_argv[]) {
-    printf("[Init:PID %ld] Running inside container namespace\n", (long)getpid());
-
-    int init_state = 0;
+    printf("[Init:PID %ld] Running inside container namespace\n",
+           (long)getpid());
 
     // set hostname
     if (sethostname(CONTAINER_HOSTNAME, strlen(CONTAINER_HOSTNAME)) == -1) {
         perror("[Init] sethostname failed");
     }
-    
-    init_state += 1;
 
     // make mounts private
     if (mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL) == -1) {
         perror("[Init] Failed to make root private");
+        _exit(EXIT_FAILURE);
+    }
+
+    // bind mount the new root onto itself before pivot
+    if (mount(NEW_ROOT_PATH, NEW_ROOT_PATH, NULL, MS_BIND | MS_REC, NULL) ==
+        -1) {
+        perror("[Init] Failed to bind mount new root");
+        _exit(EXIT_FAILURE);
+    }
+
+    // create directory for old root inside the new root
+    snprintf(
+      old_root_path, sizeof(old_root_path), "%s/old_root", NEW_ROOT_PATH);
+    if (mkdir(old_root_path, 0700) == -1 && errno != EEXIST) {
+        perror("[Init] Failed to create old_root directory");
+        umount2(NEW_ROOT_PATH, MNT_DETACH);
+        _exit(EXIT_FAILURE);
+    }
+
+    // pivot root
+    if (syscall(SYS_pivot_root, NEW_ROOT_PATH, old_root_path) == -1) {
+        perror("[Init] Failed to pivot_root (syscall)");
+        umount2(NEW_ROOT_PATH, MNT_DETACH);
+        rmdir(old_root_path);
+        _exit(EXIT_FAILURE);
+    }
+
+    // change to the new root directory
+    if (chdir("/") == -1) {
+        perror("[Init] Failed to change directory to new root");
+        umount2("/old_root", MNT_DETACH);
+        _exit(EXIT_FAILURE);
+    }
+
+    // unmount old root
+    if (umount2("/old_root", MNT_DETACH) == -1) {
+        perror("[Init] Warning: Failed to unmount /old_root");
+        // Continue, might leave clutter
+    } else {
+        printf("[Init] Unmounted /old_root\n");
+        if (rmdir("/old_root") == -1) {
+            perror("[Init] Warning: Failed to remove /old_root directory");
+        } else {
+            printf("[Init] Removed /old_root directory\n");
         }
-    
+    }
+
     // mount proc
-    if (mount("proc", "/proc", "proc", MS_NOSUID | MS_NODEV | MS_NOEXEC, NULL) == -1) {
+    if (mount(
+          "proc", "/proc", "proc", MS_NOSUID | MS_NODEV | MS_NOEXEC, NULL) ==
+        -1) {
         perror("[Init] Failed to mount /proc");
+        _exit(EXIT_FAILURE);
     }
 
-    init_state += 1;
+    // mount sys read-only
+    if (mkdir("/sys", 0555) == -1 && errno != EEXIST) {
+        perror("[Init] Failed to create /sys directory");
+        _exit(EXIT_FAILURE);
+    }
+    if (mount("sysfs",
+              "/sys",
+              "sysfs",
+              MS_RDONLY | MS_NOSUID | MS_NODEV | MS_NOEXEC,
+              NULL) == -1) {
+        perror("[Init] Failed to mount /sys");
+        // _exit(EXIT_FAILURE);
+    }
+    printf("[Init] Mounted /sys.\n");
 
-    // init handle_cleanup_post_error(int* init_state)
-    switch(init_state) {
-        case 0:
-        case 1:
-        case 2:
-            printf("[Init:PID %ld] Container startup failed at step: %d\n", (long)getpid(), init_state);
-            return EXIT_FAILURE;
-        default:
-            printf("[Init:PID %ld] Init state: Successfully started.\n", (long)getpid());
+    // mount devtmpfs
+    if (mkdir("/dev", 0755) == -1 && errno != EEXIST) {
+        perror("[Init] Failed to create /dev directory");
+        _exit(EXIT_FAILURE);
     }
 
+    if (mount("tmpfs",
+              "/dev",
+              "tmpfs",
+              MS_NOSUID | MS_STRICTATIME,
+              "mode=0755,size=65536k") == -1) {
+        perror("[Init] Failed to mount tmpfs on /dev");
+        _exit(EXIT_FAILURE);
+    }
+    printf("[Init] Mounted tmpfs on /dev\n");
 
-    printf("[Init:PID %ld] Executing final command: %s\n", (long)getpid(), command_argv[0]);
+    if (mkdir("/dev/pts", 0755) == -1 && errno != EEXIST) {
+        perror("[Init] Failed to create /dev/pts");
+        umount2("/dev", MNT_DETACH);
+        _exit(EXIT_FAILURE);
+    }
+    if (mkdir("/dev/shm", 0755) == -1 && errno != EEXIST) {
+        perror("[Init] Failed to create /dev/shm");
+        umount2("/dev", MNT_DETACH);
+        _exit(EXIT_FAILURE);
+    }
+
+    if (mknod("/dev/null", S_IFCHR | 0666, makedev(1, 3)) == -1 ||
+        mknod("/dev/zero", S_IFCHR | 0666, makedev(1, 5)) == -1 ||
+        mknod("/dev/full", S_IFCHR | 0666, makedev(1, 7)) == -1 ||
+        mknod("/dev/random", S_IFCHR | 0666, makedev(1, 8)) == -1 ||
+        mknod("/dev/urandom", S_IFCHR | 0666, makedev(1, 9)) == -1 ||
+        mknod("/dev/tty", S_IFCHR | 0666, makedev(5, 0)) == -1 ||
+        mknod("/dev/console", S_IFCHR | 0600, makedev(5, 1)) == -1) {
+        perror("[Init] Failed to create standard device nodes in /dev");
+        umount2("/dev/shm", MNT_DETACH);
+        umount2("/dev/pts", MNT_DETACH);
+        umount2("/dev", MNT_DETACH);
+        _exit(EXIT_FAILURE);
+    }
+    printf("[Init] Created /dev/null, zero, full, random, urandom, tty.\n");
+
+    if (mount("devpts", "/dev/pts", "devpts", MS_NOSUID | MS_NOEXEC, NULL) ==
+        -1) {
+        perror("[Init] Failed to mount devpts on /dev/pts");
+        umount2("/dev", MNT_DETACH);
+        _exit(EXIT_FAILURE);
+    }
+    printf("[Init] Mounted devpts on /dev/pts\n");
+
+    if (mount(
+          "tmpfs", "/dev/shm", "tmpfs", MS_NOSUID | MS_NODEV, "mode=1777") ==
+        -1) {
+        perror("[Init] Failed to mount tmpfs on /dev/shm");
+        umount2("/dev/pts", MNT_DETACH);
+        umount2("/dev", MNT_DETACH);
+        _exit(EXIT_FAILURE);
+    }
+    printf("[Init] Mounted tmpfs on /dev/shm\n");
+
+    if (symlink("/proc/self/fd/0", "/dev/stdin") == -1 && errno != EEXIST) {
+        perror("[Init] Warning: Failed to create /dev/stdin symlink");
+    } else {
+        printf("[Init] Created /dev/stdin symlink\n");
+    }
+
+    if (symlink("/proc/self/fd/1", "/dev/stdout") == -1 && errno != EEXIST) {
+        perror("[Init] Warning: Failed to create /dev/stdout symlink");
+    } else {
+        printf("[Init] Created /dev/stdout symlink\n");
+    }
+
+    if (symlink("/proc/self/fd/2", "/dev/stderr") == -1 && errno != EEXIST) {
+        perror("[Init] Warning: Failed to create /dev/stderr symlink");
+    } else {
+        printf("[Init] Created /dev/stderr symlink\n");
+    }
+
+    printf("[Init:PID %ld] Executing final command: %s\n",
+           (long)getpid(),
+           command_argv[0]);
     execvp(command_argv[0], command_argv);
 
     perror("[Init] execvp failed");
-    return EXIT_FAILURE;
+    _exit(EXIT_FAILURE);
 }
 
-
-int wait_container(libcapsule_container_state_t *state) {
-    if (!state || state->host_pid <= 0) { // Check host_pid is valid *before* assuming stack exists
+int
+wait_container(libcapsule_container_state_t* state)
+{
+    if (!state ||
+        state->host_pid <=
+          0) { // Check host_pid is valid *before* assuming stack exists
         errno = EINVAL;
         return -1;
     }
@@ -141,17 +282,13 @@ int wait_container(libcapsule_container_state_t *state) {
     int status;
     pid_t result = waitpid(state->host_pid, &status, 0);
 
-    int ret_val = 0; // Assume success initially
+    int ret_val = 0;
 
     if (result == -1) {
         perror("[Parent] waitpid failed");
-
-
-
-        ret_val = -1; // waitpid failed
+        ret_val = -1;
         state->exit_status = -1; // Indicate unknown exit status
     } else {
-
         if (WIFEXITED(status)) {
             state->exit_status = WEXITSTATUS(status);
         } else if (WIFSIGNALED(status)) {
@@ -161,12 +298,10 @@ int wait_container(libcapsule_container_state_t *state) {
         }
     }
 
-    
     if (state->child_stack != NULL) {
         free(state->child_stack);
-        state->child_stack = NULL; 
+        state->child_stack = NULL;
     }
 
-
-    return ret_val; // Return 0 if waitpid succeeded, -1 if it failed
+    return ret_val;
 }

--- a/src/libcapsule/libcapsule.h
+++ b/src/libcapsule/libcapsule.h
@@ -6,36 +6,48 @@
 /*
 clone()
  * The clone() system call is used to create a new process (or thread) in Linux.
- * It allows for fine-grained control over what resources are shared between the parent and child processes.
+ * It allows for fine-grained control over what resources are shared between the
+parent and child processes.
  * The flags used in the clone() call determine the behavior of the new process.
- * For example, CLONE_NEWPID creates a new PID namespace, while CLONE_NEWNS creates a new mount namespace.
+ * For example, CLONE_NEWPID creates a new PID namespace, while CLONE_NEWNS
+creates a new mount namespace.
  *
- * The child process can then perform operations like changing the root filesystem and setting up its environment.
- * The parent process must wait for the child to finish its setup before proceeding.
+ * The child process can then perform operations like changing the root
+filesystem and setting up its environment.
+ * The parent process must wait for the child to finish its setup before
+proceeding.
 
- * The clone() syscall does not inherit the stack, like fork() does, so one must be assigned to the child process.
+ * The clone() syscall does not inherit the stack, like fork() does, so one must
+be assigned to the child process.
 */
 
 #define STACK_SIZE (1024 * 1024) // 1MB
 #define CONTAINER_HOSTNAME "container-1"
+#define NEW_ROOT_PATH "/tmp/mycontainer_root" // Path to the prepared rootfs
 
-typedef struct libcapsule_container_state {
-    pid_t host_pid;     
-    int exit_status;    
-    void *child_stack; 
-    } libcapsule_container_state_t;
+typedef struct libcapsule_container_state
+{
+    pid_t host_pid;
+    int exit_status;
+    void* child_stack;
+} libcapsule_container_state_t;
 
 // Create container with raw argv (advanced)
 // argv[0] = command, argv[1..N] = args, NULL-terminated
-int create_container_argv(char *const argv[], libcapsule_container_state_t *state);
+int
+create_container_argv(char* const argv[], libcapsule_container_state_t* state);
 
 // Create container from single shell command (simpler API)
-int create_container_simple(const char *command, libcapsule_container_state_t *state);
+int
+create_container_simple(const char* command,
+                        libcapsule_container_state_t* state);
 
 // Init phase (called inside container)
-int init_container(const char *program_name, char *const command_argv[]);
+int
+init_container(const char* program_name, char* const command_argv[]);
 
 // Wait for container process to exit
-int wait_container(libcapsule_container_state_t *state);
+int
+wait_container(libcapsule_container_state_t* state);
 
 #endif // LIBCAPSULE_H

--- a/src/main.c
+++ b/src/main.c
@@ -4,10 +4,15 @@
 #include <string.h>
 #include <unistd.h>
 
-int main(int argc, char *argv[]) {
+int
+main(int argc, char* argv[])
+{
     if (argc > 1 && strcmp(argv[1], "init") == 0) {
         if (argc < 3) {
-            fprintf(stderr, "[Init:%ld] Error: 'init' phase requires a command argument.\n", (long)getpid());
+            fprintf(
+              stderr,
+              "[Init:%ld] Error: 'init' phase requires a command argument.\n",
+              (long)getpid());
             exit(EXIT_FAILURE);
         }
         exit(init_container(argv[0], &argv[2]));
@@ -15,11 +20,15 @@ int main(int argc, char *argv[]) {
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <command> [args...]\n", argv[0]);
         fprintf(stderr, "Example: %s /bin/bash\n", argv[0]);
-        fprintf(stderr, "Example: %s /bin/sh -c \"echo Container PID is \\$\\$; hostname\"\n", argv[0]);
+        fprintf(
+          stderr,
+          "Example: %s /bin/sh -c \"echo Container PID is \\$\\$; hostname\"\n",
+          argv[0]);
         exit(EXIT_FAILURE);
     }
 
-    libcapsule_container_state_t state; // Holds container PID, exit status, stack ptr
+    libcapsule_container_state_t
+      state; // Holds container PID, exit status, stack ptr
 
     printf("[Parent] Creating container for command:");
     for (int i = 1; i < argc; i++) {


### PR DESCRIPTION
## Summary of Changes

This PR adds to  the `init_container` function to provide a more complete and isolated container environment by implementing `pivot_root` and setting up essential virtual filesystems.

## Detailed Changes
- edited readme.md to mention changes

*   **Implemented `pivot_root`:**
    *   The `init_container` function now uses the `pivot_root` system call to switch the container's root filesystem to `NEW_ROOT_PATH`.
    *   Includes the necessary steps: bind-mounting the new root, creating `/old_root`, calling `pivot_root`, changing directory (`chdir`), unmounting, and removing `/old_root`.
*   **Mounted Essential Filesystems:**
    *   Mounts `/proc` (as before).
    *   Mounts `/sys` (`sysfs`, read-only).
    *   Mounts `/dev` (`tmpfs`).
    *   Mounts `/dev/pts` (`devpts`).
    *   Mounts `/dev/shm` (`tmpfs`).
*   **Populated `/dev`:**
    *   Creates standard device nodes using `mknod`: `/dev/null`, `/dev/zero`, `/dev/full`, `/dev/random`, `/dev/urandom`, `/dev/tty`, `/dev/console`.
    *   Creates standard symlinks: `/dev/stdin`, `/dev/stdout`, `/dev/stderr` pointing to `/proc/self/fd/*`.
*   **Improved Error Handling:**
    *   Removed the previous `init_state` tracking variable.
    *   Critical errors during initialization (e.g., `pivot_root`, `mount` failures) now call `perror` and immediately terminate the init process using `_exit(EXIT_FAILURE)`.
*   **Included Headers:**
    *   Added `<sys/stat.h>`, `<sys/syscall.h>`, and `<sys/sysmacros.h>` to support the new functionality.